### PR TITLE
chore: add typedoc config and docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,15 @@
+name: 📚 Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    uses: echecsjs/.github/.github/workflows/docs.yml@main
+    secrets: inherit

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": ["src/index.ts"],
+  "excludeInternal": false,
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "includeVersion": true,
+  "out": "docs/api",
+  "readme": "README.md",
+  "sort": ["source-order"]
+}


### PR DESCRIPTION
adds `typedoc.json` and `.github/workflows/docs.yml` to generate and deploy TypeDoc API reference to GitHub Pages.