### PR TITLE
chore: add packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@echecs/san",
+  "packageManager": "pnpm@10.33.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/echecsjs/san.git"


### PR DESCRIPTION
adds packageManager to package.json — helps dependabot detect the pnpm ecosystem