### PR TITLE
chore: add missing import-x rules to eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,11 @@ export default typescript.config(
     rules: {
       'curly': ['error', 'all'],
       'eqeqeq': 'error',
+      'import-x/exports-last': 'error',
+      'import-x/first': 'error',
+      'import-x/group-exports': 'error',
+      'import-x/newline-after-import': 'error',
+      'import-x/no-duplicates': 'error',
       'import-x/order': [
         'error',
         {


### PR DESCRIPTION
adds the 5 `import-x/` rules (`exports-last`, `first`, `group-exports`, `newline-after-import`, `no-duplicates`) already present in all other `@echecs/*` packages.