### PR TITLE
feat!: align SAN with pgn's Move

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,9 @@ Notation (SAN) chess moves.
 
 | Function               | Input                   | Output     | Throws                                |
 | ---------------------- | ----------------------- | ---------- | ------------------------------------- |
-| `parse(san)`           | SAN string              | `SanMove`  | `RangeError` on empty/invalid input   |
+| `parse(san)`           | SAN string              | `SAN`      | `RangeError` on empty/invalid input   |
 | `parse(san, position)` | SAN string + `Position` | `Move`     | `RangeError` on empty/invalid/illegal |
-| `resolve()`            | `SanMove` + `Position`  | `Move`     | `RangeError` on illegal/ambiguous     |
+| `resolve()`            | `SAN` + `Position`      | `Move`     | `RangeError` on illegal/ambiguous     |
 | `stringify()`          | `Move` + `Position`     | SAN string | `RangeError` if no piece on square    |
 
 The entire implementation lives in a single source file: `src/index.ts`.
@@ -55,14 +55,6 @@ checks, assertion functions) unless there is an explicit trust boundary.
 
 - **ESM-only** — the package ships only ESM. Do not add a CJS build.
 
-### `@echecs/position/internal`
-
-`canAttack` and `isKingInCheck` use the 0x88 lookup tables (`ATTACKS`, `RAYS`,
-`PIECE_MASKS`, `DIFF_OFFSET`, `OFF_BOARD`) and the `boardFromMap` /
-`squareToIndex` helpers from `@echecs/position/internal`. This is the only
-package besides `@echecs/game` that may use the `./internal` export condition.
-Do not use it in application code.
-
 ### SAN regex
 
 The regex at the top of `src/index.ts` parses the full SAN grammar in one pass.
@@ -75,13 +67,11 @@ Regex group order:
 ### `resolve()` logic
 
 1. Iterate all pieces of the active color matching `move.piece`.
-2. Apply file/rank disambiguation filters.
-3. For pawns: validate direction and distance separately for pushes vs. captures
-   (the generic `canAttack` table does not model pawn pushes).
-4. For all other pieces: use `canAttack` with the 0x88 tables.
-5. Apply the move with `applyMoveToBoard` and discard candidates that leave the
-   own king in check (`isKingInCheck`).
-6. Exactly one candidate must remain — zero or many both throw `RangeError`.
+2. Apply `from` disambiguation filter (file, rank, or full square).
+3. Use `position.reach()` to check if the piece can reach the target square.
+4. Apply the move with `applyMoveToBoard` and discard candidates that leave the
+   own king in check.
+5. Exactly one candidate must remain — zero or many both throw `RangeError`.
 
 ### `stringify()` disambiguation
 
@@ -93,8 +83,8 @@ When multiple pieces of the same type can reach the destination:
 
 ### `isCheckmate()` simplification
 
-The internal `isCheckmate` helper iterates all 0x88 indices and attempts every
-`canAttack`-reachable move. It is intentionally simple (not perft- optimised)
+The internal `isCheckmate` helper iterates all pieces and attempts every
+`reach()`-reachable move. It is intentionally simple (not perft-optimised)
 because it is only called from `stringify()` to append `#`.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this
 project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.0.0] - 2026-04-26
+
+### Changed
+
+- Renamed `SanMove` to `SAN`.
+- Renamed `PromotionPieceType` to `PromotionPiece`.
+- Merged `file` + `rank` fields into `from: Disambiguation | undefined` where
+  `Disambiguation = File | Rank | Square`.
+- Replaced `castle: 'kingside' | 'queenside' | undefined` with
+  `castling: boolean` + `long: boolean`.
+- Replaced `check: 'check' | 'checkmate' | undefined` with `check: boolean` +
+  `checkmate: boolean`.
+
+### Added
+
+- Exported `Piece` type
+  (`'bishop' | 'king' | 'knight' | 'pawn' | 'queen' | 'rook'`).
+- Exported `Disambiguation` type (`File | Rank | Square`).
+- Re-exported `File`, `Rank`, `Square` from `@echecs/position`.
+
 ## [2.0.3] - 2026-04-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
   },
   "type": "module",
   "types": "dist/index.d.ts",
-  "version": "2.0.3"
+  "version": "3.0.0"
 }

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -28,8 +28,9 @@ describe('parse — pawn moves', () => {
     expect(move.piece).toBe('pawn');
     expect(move.to).toBe('e4');
     expect(move.capture).toBe(false);
-    expect(move.castle).toBeUndefined();
-    expect(move.check).toBeUndefined();
+    expect(move.castling).toBe(false);
+    expect(move.check).toBe(false);
+    expect(move.checkmate).toBe(false);
     expect(move.promotion).toBeUndefined();
   });
 
@@ -37,7 +38,7 @@ describe('parse — pawn moves', () => {
     const move = parse('exd5');
     expect(move.piece).toBe('pawn');
     expect(move.capture).toBe(true);
-    expect(move.file).toBe('e');
+    expect(move.from).toBe('e');
     expect(move.to).toBe('d5');
   });
 
@@ -52,7 +53,8 @@ describe('parse — pawn moves', () => {
     const move = parse('exd8=Q#');
     expect(move.capture).toBe(true);
     expect(move.promotion).toBe('queen');
-    expect(move.check).toBe('checkmate');
+    expect(move.check).toBe(false);
+    expect(move.checkmate).toBe(true);
   });
 });
 
@@ -74,50 +76,63 @@ describe('parse — piece moves', () => {
   it('parses file disambiguation', () => {
     const move = parse('Nbd7');
     expect(move.piece).toBe('knight');
-    expect(move.file).toBe('b');
+    expect(move.from).toBe('b');
     expect(move.to).toBe('d7');
   });
 
   it('parses rank disambiguation', () => {
     const move = parse('N2d4');
     expect(move.piece).toBe('knight');
-    expect(move.rank).toBe('2');
+    expect(move.from).toBe('2');
     expect(move.to).toBe('d4');
   });
 });
 
 describe('parse — check and checkmate', () => {
   it('parses check suffix', () => {
-    expect(parse('Nf3+').check).toBe('check');
+    const move = parse('Nf3+');
+    expect(move.check).toBe(true);
+    expect(move.checkmate).toBe(false);
   });
 
   it('parses checkmate suffix', () => {
-    expect(parse('Qxh7#').check).toBe('checkmate');
+    const move = parse('Qxh7#');
+    expect(move.check).toBe(false);
+    expect(move.checkmate).toBe(true);
   });
 });
 
 describe('parse — castling', () => {
   it('parses kingside castling', () => {
     const move = parse('O-O');
-    expect(move.castle).toBe('kingside');
+    expect(move.castling).toBe(true);
+    expect(move.long).toBe(false);
     expect(move.to).toBeUndefined();
     expect(move.piece).toBe('king');
   });
 
   it('parses queenside castling', () => {
-    expect(parse('O-O-O').castle).toBe('queenside');
+    const move = parse('O-O-O');
+    expect(move.castling).toBe(true);
+    expect(move.long).toBe(true);
   });
 
   it('parses castling with check', () => {
-    expect(parse('O-O+').check).toBe('check');
+    const move = parse('O-O+');
+    expect(move.check).toBe(true);
+    expect(move.checkmate).toBe(false);
   });
 
   it('parses kingside castling with checkmate', () => {
-    expect(parse('O-O#').check).toBe('checkmate');
+    const move = parse('O-O#');
+    expect(move.check).toBe(false);
+    expect(move.checkmate).toBe(true);
   });
 
   it('parses queenside castling with checkmate', () => {
-    expect(parse('O-O-O#').check).toBe('checkmate');
+    const move = parse('O-O-O#');
+    expect(move.check).toBe(false);
+    expect(move.checkmate).toBe(true);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type {
+  Piece as BoardPiece,
   Color,
   File,
-  Piece,
   PieceType,
   Position,
   Rank,
@@ -12,22 +12,27 @@ import type {
 // Types owned by this package
 // ---------------------------------------------------------------------------
 
-type PromotionPieceType = 'bishop' | 'knight' | 'queen' | 'rook';
+type Disambiguation = File | Rank | Square;
+
+type Piece = PieceType;
+
+type PromotionPiece = 'bishop' | 'knight' | 'queen' | 'rook';
 
 interface Move {
   from: Square;
-  promotion?: PromotionPieceType;
+  promotion?: PromotionPiece;
   to: Square;
 }
 
-interface SanMove {
+interface SAN {
   capture: boolean;
-  castle: 'kingside' | 'queenside' | undefined;
-  check: 'check' | 'checkmate' | undefined;
-  file: File | undefined;
-  piece: PieceType;
-  promotion: PromotionPieceType | undefined;
-  rank: Rank | undefined;
+  castling: boolean;
+  check: boolean;
+  checkmate: boolean;
+  from: Disambiguation | undefined;
+  long: boolean;
+  piece: Piece;
+  promotion: PromotionPiece | undefined;
   to: Square | undefined;
 }
 
@@ -35,7 +40,7 @@ interface SanMove {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-const PIECE_LETTERS: Record<string, PieceType> = {
+const PIECE_LETTERS: Record<string, Piece> = {
   B: 'bishop',
   K: 'king',
   N: 'knight',
@@ -43,7 +48,7 @@ const PIECE_LETTERS: Record<string, PieceType> = {
   R: 'rook',
 };
 
-const PROMOTION_LETTERS: Record<string, PromotionPieceType> = {
+const PROMOTION_LETTERS: Record<string, PromotionPiece> = {
   B: 'bishop',
   N: 'knight',
   Q: 'queen',
@@ -63,14 +68,14 @@ function applyMoveToBoard(
   position: Position,
   from: Square,
   to: Square,
-  promotion?: PromotionPieceType,
+  promotion?: PromotionPiece,
 ): Position {
   const piece = position.at(from);
   if (piece === undefined) {
     return position;
   }
 
-  const changes: [Square, Piece | undefined][] = [
+  const changes: [Square, BoardPiece | undefined][] = [
     [from, undefined],
     [to, promotion ? { color: piece.color, type: promotion } : piece],
   ];
@@ -111,9 +116,9 @@ function applyMoveToBoard(
 // parse()
 // ---------------------------------------------------------------------------
 
-function parse(san: string): SanMove;
+function parse(san: string): SAN;
 function parse(san: string, position: Position): Move;
-function parse(san: string, position?: Position): SanMove | Move {
+function parse(san: string, position?: Position): SAN | Move {
   if (san.length === 0) {
     throw new RangeError('Empty SAN string');
   }
@@ -123,19 +128,15 @@ function parse(san: string, position?: Position): SanMove | Move {
 
   // Castling
   if (clean.startsWith('O-O-O')) {
-    const check = clean.endsWith('#')
-      ? 'checkmate'
-      : clean.endsWith('+')
-        ? 'check'
-        : undefined;
-    const sanMove: SanMove = {
+    const sanMove: SAN = {
       capture: false,
-      castle: 'queenside',
-      check,
-      file: undefined,
+      castling: true,
+      check: clean.endsWith('+'),
+      checkmate: clean.endsWith('#'),
+      from: undefined,
+      long: true,
       piece: 'king',
       promotion: undefined,
-      rank: undefined,
       to: undefined,
     };
 
@@ -147,19 +148,15 @@ function parse(san: string, position?: Position): SanMove | Move {
   }
 
   if (clean.startsWith('O-O')) {
-    const check = clean.endsWith('#')
-      ? 'checkmate'
-      : clean.endsWith('+')
-        ? 'check'
-        : undefined;
-    const sanMove: SanMove = {
+    const sanMove: SAN = {
       capture: false,
-      castle: 'kingside',
-      check,
-      file: undefined,
+      castling: true,
+      check: clean.endsWith('+'),
+      checkmate: clean.endsWith('#'),
+      from: undefined,
+      long: false,
       piece: 'king',
       promotion: undefined,
-      rank: undefined,
       to: undefined,
     };
 
@@ -187,7 +184,7 @@ function parse(san: string, position?: Position): SanMove | Move {
     checkString,
   ] = match;
 
-  const piece: PieceType = pieceString
+  const piece: Piece = pieceString
     ? (PIECE_LETTERS[pieceString] ?? 'pawn')
     : 'pawn';
   const file =
@@ -204,21 +201,23 @@ function parse(san: string, position?: Position): SanMove | Move {
     promoString && PROMOTION_LETTERS[promoString]
       ? PROMOTION_LETTERS[promoString]
       : undefined;
-  const check =
-    checkString === '#'
-      ? 'checkmate'
-      : checkString === '+'
-        ? 'check'
-        : undefined;
+  const check = checkString === '+';
+  const checkmate = checkString === '#';
 
-  const sanMove: SanMove = {
+  const from: Disambiguation | undefined =
+    file !== undefined && rank !== undefined
+      ? (`${file}${rank}` as Square)
+      : (file ?? rank ?? undefined);
+
+  const sanMove: SAN = {
     capture,
-    castle: undefined,
+    castling: false,
     check,
-    file,
+    checkmate,
+    from,
+    long: false,
     piece,
     promotion,
-    rank,
     to,
   };
 
@@ -233,20 +232,19 @@ function parse(san: string, position?: Position): SanMove | Move {
 // resolve()
 // ---------------------------------------------------------------------------
 
-function resolve(move: SanMove, position: Position): Move {
+function resolve(move: SAN, position: Position): Move {
   // Castling
-  if (move.castle !== undefined) {
+  if (move.castling) {
     const backRank = position.turn === 'white' ? '1' : '8';
     const from = `e${backRank}` as Square;
-    const to =
-      move.castle === 'kingside'
-        ? (`g${backRank}` as Square)
-        : (`c${backRank}` as Square);
+    const to = move.long
+      ? (`c${backRank}` as Square)
+      : (`g${backRank}` as Square);
     return { from, promotion: undefined, to };
   }
 
   if (move.to === undefined) {
-    throw new RangeError('SanMove has no target square');
+    throw new RangeError('SAN has no target square');
   }
 
   const candidates: Square[] = [];
@@ -255,11 +253,25 @@ function resolve(move: SanMove, position: Position): Move {
     if (piece.type !== move.piece) {
       continue;
     }
-    if (move.file !== undefined && square[0] !== move.file) {
-      continue;
-    }
-    if (move.rank !== undefined && square[1] !== move.rank) {
-      continue;
+
+    // Apply disambiguation filter
+    if (move.from !== undefined) {
+      if (move.from.length === 2) {
+        // Full square disambiguation
+        if (square !== move.from) {
+          continue;
+        }
+      } else if (FILES_SET.has(move.from)) {
+        // File disambiguation
+        if (square[0] !== move.from) {
+          continue;
+        }
+      } else {
+        // Rank disambiguation
+        if (square[1] !== move.from) {
+          continue;
+        }
+      }
     }
 
     // Check if piece can reach the target square
@@ -303,7 +315,7 @@ function resolve(move: SanMove, position: Position): Move {
 // stringify()
 // ---------------------------------------------------------------------------
 
-const PIECE_TO_LETTER: Record<PieceType, string> = {
+const PIECE_TO_LETTER: Record<Piece, string> = {
   bishop: 'B',
   king: 'K',
   knight: 'N',
@@ -312,7 +324,7 @@ const PIECE_TO_LETTER: Record<PieceType, string> = {
   rook: 'R',
 };
 
-const PROMOTION_TO_LETTER: Record<PromotionPieceType, string> = {
+const PROMOTION_TO_LETTER: Record<PromotionPiece, string> = {
   bishop: 'B',
   knight: 'N',
   queen: 'Q',
@@ -421,6 +433,6 @@ function isCheckmate(position: Position): boolean {
   return true;
 }
 
-export type { Move, PromotionPieceType, SanMove };
-export type { Position } from '@echecs/position';
+export type { Disambiguation, Move, Piece, PromotionPiece, SAN };
+export type { File, Position, Rank, Square } from '@echecs/position';
 export { parse, resolve, stringify };


### PR DESCRIPTION
## Summary

- renamed `SanMove` to `SAN`, `PromotionPieceType` to `PromotionPiece`
- merged `file` + `rank` into `from: Disambiguation | undefined`
- replaced `castle: 'kingside' | 'queenside' | undefined` with `castling: boolean` + `long: boolean`
- replaced `check: 'check' | 'checkmate' | undefined` with `check: boolean` + `checkmate: boolean`
- added `Piece` and `Disambiguation` type exports
- re-exported `File`, `Rank`, `Square` from `@echecs/position`
- updated AGENTS.md architecture notes (were stale since v2.0.0)

major version bump to 3.0.0.

closes #22