### PR TITLE
fix: move @echecs/position to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "bugs": {
     "url": "https://github.com/echecsjs/san/issues"
   },
-  "dependencies": {
-    "@echecs/position": "^3.0.3"
-  },
   "description": "Parse, resolve, and stringify SAN (Standard Algebraic Notation) chess moves. Strict TypeScript.",
   "devDependencies": {
     "@echecs/fen": "^2.1.1",
+    "@echecs/position": "^3.0.3",
     "@eslint/js": "^10.0.1",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/coverage-v8": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,13 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@echecs/position':
-        specifier: ^3.0.3
-        version: 3.0.5
     devDependencies:
       '@echecs/fen':
         specifier: ^2.1.1
         version: 2.1.1
+      '@echecs/position':
+        specifier: ^3.0.3
+        version: 3.0.5
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)


### PR DESCRIPTION
## Summary

- moves `@echecs/position` from `dependencies` to `devDependencies` — all imports are `import type`, so there is no runtime dependency
- consumers no longer pull `@echecs/position` (and transitively `@echecs/zobrist`) just by installing `@echecs/san`

closes #24