### PR TITLE
release: @echecs/san@3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this
 project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.1.0] - 2026-04-28
+
+### Added
+
+- Re-exported `Move` and `PromotionPieceType` from `@echecs/position`.
+- `PromotionPiece` remains as a type alias for backward compatibility.
+
+### Changed
+
+- `Move` and `PromotionPiece` are now imported from `@echecs/position` instead
+  of being defined locally.
+
+### Fixed
+
+- Moved `@echecs/position` to `devDependencies` — it was incorrectly listed as a
+  regular dependency.
+
 ## [3.0.0] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ const san = stringify(move, position);
 
 ## API
 
-### `parse(san: string): SanMove`
+### `parse(san: string): SAN`
 
-Parses a SAN string and returns a `SanMove` describing the move's syntax. Does
-not require a position. Throws `RangeError` for empty or invalid input.
+Parses a SAN string and returns a `SAN` object describing the move's syntax.
+Does not require a position. Throws `RangeError` for empty or invalid input.
 
 ### `parse(san: string, position: Position): Move`
 
@@ -41,9 +41,9 @@ Parses and resolves a SAN string against a position in one call. Equivalent to
 calling `parse` then `resolve`. Throws `RangeError` for empty, invalid, or
 illegal input.
 
-### `resolve(move: SanMove, position: Position): Move`
+### `resolve(move: SAN, position: Position): Move`
 
-Finds the source square for a `SanMove` in the given position. Throws
+Finds the source square for a `SAN` move in the given position. Throws
 `RangeError` if no legal move matches or if the move is ambiguous.
 
 ### `stringify(move: Move, position: Position): string`
@@ -55,22 +55,24 @@ disambiguation, capture marker, check, and checkmate symbols. Throws
 ## Types
 
 ```typescript
-interface SanMove {
+interface SAN {
   capture: boolean;
-  castle: 'kingside' | 'queenside' | undefined;
-  check: 'check' | 'checkmate' | undefined;
-  file: File | undefined;
-  piece: PieceType;
-  promotion: PromotionPieceType | undefined;
-  rank: Rank | undefined;
+  castling: boolean;
+  check: boolean;
+  checkmate: boolean;
+  from: Disambiguation | undefined;
+  long: boolean;
+  piece: Piece;
+  promotion: PromotionPiece | undefined;
   to: Square | undefined;
 }
 ```
 
-`file` and `rank` are the disambiguation hints from the SAN string, not the
-destination square. `to` is `undefined` for castling moves.
+`from` is the disambiguation hint from the SAN string (a file, rank, or full
+square), not the origin square. `to` is `undefined` for castling moves.
 
-`Move` is defined locally in `@echecs/san`:
+`Move` and `PromotionPieceType` are re-exported from `@echecs/position`.
+`PromotionPiece` is an alias for `PromotionPieceType`.
 
 ```typescript
 interface Move {
@@ -80,11 +82,8 @@ interface Move {
 }
 ```
 
-`Position` is re-exported from `@echecs/position` for convenience.
-`PromotionPieceType` is the union of piece types a pawn can promote to:
-
 ```typescript
-import type { Move, Position, PromotionPieceType, SanMove } from '@echecs/san';
+import type { Move, Position, PromotionPieceType, SAN } from '@echecs/san';
 ```
 
 ## Errors

--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
   },
   "type": "module",
   "types": "dist/index.d.ts",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }


### PR DESCRIPTION
## Summary

- imports `Move` and `PromotionPieceType` from `@echecs/position` instead of defining them locally
- adds `PromotionPieceType` re-export, keeps `PromotionPiece` alias for backward compat
- fixes `@echecs/position` being listed as a regular dependency (now devDep only)
- updates README to reflect current `SAN` type shape and `Move` origin

## Changelog

see CHANGELOG.md for full details