### PR TITLE
fix: add @echecs/position as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
   "main": "dist/index.js",
   "name": "@echecs/san",
   "packageManager": "pnpm@10.33.0",
+  "peerDependencies": {
+    "@echecs/position": "^3.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/echecsjs/san.git"


### PR DESCRIPTION
## Summary

- adds `@echecs/position: ^3.0.0` as a `peerDependency` so consumers share a single copy of `Position` and avoid nominal type conflicts from `#private` fields

closes #31