### PR TITLE
fix: widen @echecs/position peer dependency range to include 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "name": "@echecs/san",
   "packageManager": "pnpm@10.33.0",
   "peerDependencies": {
-    "@echecs/position": "^3.0.0"
+    "@echecs/position": "^3.0.0 || ^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
widens `peerDependencies` range for `@echecs/position` from `^3.0.0` to `^3.0.0 || ^4.0.0` so consumers on position 4.x don't get unmet peer warnings.

closes #34