### PR TITLE
release: @echecs/san@3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this
 project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.1.2] - 2026-05-01
+
+### Fixed
+
+- Widened `@echecs/position` peer dependency range from `^3.0.0` to
+  `^3.0.0 || ^4.0.0` so consumers on position 4.x no longer get unmet peer
+  warnings.
+
+### Changed
+
+- Bumped `@echecs/position` dev dependency from `^3.1.0` to `^4.0.0`.
+
 ## [3.1.1] - 2026-05-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Parse, resolve, and stringify SAN (Standard Algebraic Notation) chess moves. Strict TypeScript.",
   "devDependencies": {
     "@echecs/fen": "^2.1.1",
-    "@echecs/position": "^3.1.0",
+    "@echecs/position": "^4.0.0",
     "@eslint/js": "^10.0.1",
     "@typescript-eslint/parser": "^8.57.0",
     "@vitest/coverage-v8": "^4.1.0",
@@ -79,5 +79,5 @@
   },
   "type": "module",
   "types": "dist/index.d.ts",
-  "version": "3.1.1"
+  "version": "3.1.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       '@echecs/position':
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^4.0.0
+        version: 4.0.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
@@ -114,8 +114,8 @@ packages:
     resolution: {integrity: sha512-VVgSn9llXDlHmNJ3J27dLnkFEWPzpa0iZCr8ZfUhpOuLBd2Yan/6+aa/mCy3RD9qbe/KgZuh8Ljw5j1PlemFFw==}
     engines: {node: '>=20'}
 
-  '@echecs/position@3.1.0':
-    resolution: {integrity: sha512-NjyPnbq4NaNfhbEtFTW61/qKLsR+BkFeus9Z/RIaHEJI7Kr0WWkjyKoU3t6FNUjFr5m+QkjV2jo6vzfElpS5hw==}
+  '@echecs/position@4.0.0':
+    resolution: {integrity: sha512-D9z+d13owPg/EEyEp2nfqhE8gbDCdWvsoULstW4bRrums0J/i3Nxc9yz7XADe8dFhV4nqAYCanrZBk9Sr6aIIw==}
     engines: {node: '>=20'}
 
   '@echecs/zobrist@1.0.2':
@@ -1758,7 +1758,7 @@ snapshots:
 
   '@echecs/fen@2.1.1': {}
 
-  '@echecs/position@3.1.0':
+  '@echecs/position@4.0.0':
     dependencies:
       '@echecs/zobrist': 1.0.2
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { parse, resolve, stringify } from '../index.js';
 
-const START = new Position(STARTING_POSITION);
+const START = new Position({ board: STARTING_POSITION });
 
 function toPosition(fen: string): Position {
   const pos = parseFen(fen);
@@ -15,7 +15,7 @@ function toPosition(fen: string): Position {
 
   const { board, castlingRights, enPassantSquare, turn } = pos;
 
-  return new Position(board, { castlingRights, enPassantSquare, turn });
+  return new Position({ board, castlingRights, enPassantSquare, turn });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- widened `@echecs/position` peer dependency range to `^3.0.0 || ^4.0.0`
- bumped `@echecs/position` dev dependency to `^4.0.0`
- updated tests for position 4.x constructor signature

closes #34