### PR TITLE
fix: drop @echecs/position v3 from peer range

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "name": "@echecs/san",
   "packageManager": "pnpm@10.33.0",
   "peerDependencies": {
-    "@echecs/position": "^3.0.0 || ^4.0.0"
+    "@echecs/position": "^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
narrows the peer dependency from `^3.0.0 || ^4.0.0` to `^4.0.0`.

the `.d.ts` imports types (`Position`, `Move`, etc.) that only exist in v4 — pairing with v3 already fails at type-check time.

closes #38