### PR TITLE
chore: add publishConfig for public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   "license": "MIT",
   "main": "dist/index.js",
   "name": "@echecs/san",
+  "publishConfig": {
+    "access": "public"
+  },
   "packageManager": "pnpm@10.33.0",
   "peerDependencies": {
     "@echecs/position": "^4.0.0"


### PR DESCRIPTION
scoped packages default to restricted on npm — this ensures public access is explicit