### PR TITLE
chore: remove unnecessary main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "typescript"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
   "name": "@echecs/san",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
ESM-only package with exports — main is a CJS-era field that is not needed