### PR TITLE
chore: normalize types field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "version": "3.1.3"
 }


### PR DESCRIPTION
uses relative ./dist/index.d.ts path consistently across all packages