### PR TITLE
chore: update homepage to echecs.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "homepage": "https://github.com/echecsjs/san#readme",
+  "homepage": "https://san.echecs.dev",
   "keywords": [
     "chess",
     "move",


### PR DESCRIPTION
points homepage to the docs site instead of the github repo