### PR TITLE
chore: add missing sideEffects field

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "test:coverage": "pnpm run test --coverage",
     "test:watch": "pnpm run test --watch"
   },
+  "sideEffects": false,
   "type": "module",
   "types": "./dist/index.d.ts",
   "version": "3.1.3"


### PR DESCRIPTION
adds `sideEffects: false` — was the only public package missing it