### PR TITLE
release: @echecs/san@4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this
 project adheres to [Semantic Versioning](https://semver.org).
 
+## [4.0.0] - 2026-05-28
+
+### Changed
+
+- **BREAKING:** `parse()` now returns `SAN | null` (or `Move | null` with a
+  position) instead of throwing `RangeError` on invalid input.
+- Added `ParseOptions` with `onError` callback, matching the `fen`/`trf`/`pgn`
+  error reporting pattern.
+- `resolve()` still throws `RangeError` on illegal/ambiguous moves.
+
+### Added
+
+- Exported `ParseError` and `ParseOptions` types.
+
 ## [3.2.0] - 2026-05-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -82,5 +82,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "3.2.0"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
- **BREAKING:** `parse()` returns `null` instead of throwing on invalid input
- added `ParseOptions` with `onError` callback
- exported `ParseError` and `ParseOptions` types