### PR TITLE
chore: restore minimumReleaseAge default, add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
       time: '13:00'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: 'chore'
       include: 'scope'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 allowBuilds:
   unrs-resolver: true
-minimumReleaseAge: 0


### PR DESCRIPTION
reverts `minimumReleaseAge: 0` to restore pnpm 11's default 1-day supply chain protection. adds `cooldown.default-days: 2` to dependabot so it waits 2 days before opening PRs for newly-published packages — ensuring they're always past pnpm's cutoff.